### PR TITLE
Update alb-controller-add-on.md

### DIFF
--- a/day-22/alb-controller-add-on.md
+++ b/day-22/alb-controller-add-on.md
@@ -43,13 +43,14 @@ helm repo update eks
 Install
 
 ```
-helm install aws-load-balancer-controller eks/aws-load-balancer-controller \            
-  -n kube-system \
+helm install aws-load-balancer-controller eks/aws-load-balancer-controller \
+  --namespace kube-system \
   --set clusterName=<your-cluster-name> \
   --set serviceAccount.create=false \
   --set serviceAccount.name=aws-load-balancer-controller \
   --set region=<region> \
   --set vpcId=<your-vpc-id>
+
 ```
 
 Verify that the deployments are running.


### PR DESCRIPTION
this resolves the 
` parse error near `\n'`
error
 the -n flag is being treated as a command rather than an argument to the helm install command.