### PR TITLE
Update iam.md

### DIFF
--- a/interview-questions/iam.md
+++ b/interview-questions/iam.md
@@ -17,7 +17,7 @@ You can secure your AWS account by enforcing the principle of least privilege, c
 IAM users are individuals or entities that have a fixed set of permissions associated with them. IAM roles are temporary credentials that can be assumed by users or AWS services to access resources.
 
 ### 7. What is an IAM policy?
-An IAM policy is a JSON document that defines permissions. It specifies what actions are allowed or denied on which AWS resources for whom (users, groups, or roles).
+An IAM policy is a JSON document that defines permissions. It specifies what actions are allowed or denied on which AWS resources for whom (users, groups, or accounts).
 
 ### 8. What is the AWS Management Console?
 The AWS Management Console is a web-based interface that allows you to interact with and manage AWS resources. IAM users can use the console to access resources based on their permissions.


### PR DESCRIPTION
Changed: `groups => accounts`
> Group is not a Principal in AWS

Principals include:
- AWS Account Root User
- IAM Users
- IAM Roles
- Federated Users
- AWS Services (Service Principals like s3.amazonaws.com)
- AWS Accounts (for cross-account access)
- Anonymous Users (*, for public access)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the explanation of IAM policy applicability to refer to "users, groups, or accounts" instead of "users, groups, or roles."

<!-- end of auto-generated comment: release notes by coderabbit.ai -->