### PR TITLE
Updated the command to install Helm

### DIFF
--- a/day-22/alb-controller-add-on.md
+++ b/day-22/alb-controller-add-on.md
@@ -43,8 +43,7 @@ helm repo update eks
 Install
 
 ```
-helm install aws-load-balancer-controller eks/aws-load-balancer-controller \            
-  -n kube-system \
+helm install aws-load-balancer-controller eks/aws-load-balancer-controller -n kube-system \
   --set clusterName=<your-cluster-name> \
   --set serviceAccount.create=false \
   --set serviceAccount.name=aws-load-balancer-controller \


### PR DESCRIPTION
Installation of Helm:
There was a wide space in between the first line and the second line ( -n kube-system \) causing the entire command to fail.  I fixed it the way you did in the demo video, but you did forget to modify it in the repo.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved the formatting of the AWS Load Balancer Controller installation command for better readability and conciseness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->