### PR TITLE
Update alb-controller-add-on.md remove whitespace in ALB

### DIFF
--- a/day-22/alb-controller-add-on.md
+++ b/day-22/alb-controller-add-on.md
@@ -43,12 +43,11 @@ helm repo update eks
 Install
 
 ```
-helm install aws-load-balancer-controller eks/aws-load-balancer-controller \            
-  -n kube-system \
+helm install aws-load-balancer-controller eks/aws-load-balancer-controller -n kube-system \
   --set clusterName=<your-cluster-name> \
   --set serviceAccount.create=false \
   --set serviceAccount.name=aws-load-balancer-controller \
-  --set region=<region> \
+  --set region=<your-region> \
   --set vpcId=<your-vpc-id>
 ```
 


### PR DESCRIPTION
removed the whitespace that was causing issue.
Error: INSTALLATION FAILED: expected at most two arguments, unexpected arguments:  -n, kube-system
After the change command executed  without any issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated installation instructions for the AWS Load Balancer Controller to use a single-line command and clarified the region placeholder.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->