### PR TITLE
Update requirements.txt

### DIFF
--- a/day-21/requirements.txt
+++ b/day-21/requirements.txt
@@ -1,1 +1,2 @@
-Flask==2.0.1
+Flask==2.0.3
+Werkzeug==2.0.3


### PR DESCRIPTION
❌ Error:
ImportError: cannot import name 'url_quote' from 'werkzeug.urls'

You're using a newer version of Werkzeug in which url_quote has been removed or renamed — but Flask (or your code or another dependency) is still trying to import it.

This is a known compatibility issue between:

Flask version <2.x

and Werkzeug version >=2.1.0

In your Dockerfile or requirements.txt, pin Werkzeug to a compatible version, like this:

✅ Option 1: requirements.txt

Flask==2.0.3
Werkzeug==2.0.3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Upgraded Flask dependency to version 2.0.3.
  * Added Werkzeug version 2.0.3 as a new dependency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->