### PR TITLE
Update userdata1.sh

### DIFF
--- a/day-24/userdata1.sh
+++ b/day-24/userdata1.sh
@@ -2,8 +2,13 @@
 apt update
 apt install -y apache2
 
-# Get the instance ID using the instance metadata
-INSTANCE_ID=$(curl -s http://169.254.169.254/latest/meta-data/instance-id)
+# Get a metadata token
+TOKEN=$(curl -s -X PUT "http://169.254.169.254/latest/api/token" \
+  -H "X-aws-ec2-metadata-token-ttl-seconds: 21600")
+
+# Get the instance ID using the token
+INSTANCE_ID=$(curl -s -H "X-aws-ec2-metadata-token: $TOKEN" \
+  http://169.254.169.254/latest/meta-data/instance-id)
 
 # Install the AWS CLI
 apt install -y awscli


### PR DESCRIPTION
AWS AMIs now default to IMDSv2, which is more secure. IMDSv2 requires a session token to access metadata. Using the IMDSv1 URL without a token often returns empty or fails silently.